### PR TITLE
feat(skip): add dynamic skip detail panel with 'New' tag and full data support

### DIFF
--- a/src/components/SkipCard.jsx
+++ b/src/components/SkipCard.jsx
@@ -1,7 +1,10 @@
 import { ArrowRight, Check, AlertTriangle, X } from "lucide-react";
+import { getSkipImageUrl } from "../utils/getSkipImageUrl";
+// import { isNew } from "../utils/isNew";
+import { shouldShowNew } from "../utils/shouldShowNew";
 
 const SkipCard = ({ data, selected, onSelect }) => {
-  const imageUrl = `/images/${data.size}-yarder-skip.jpg`;
+  const imageUrl = getSkipImageUrl(data.size);
 
   return (
     <div
@@ -9,6 +12,12 @@ const SkipCard = ({ data, selected, onSelect }) => {
     ${selected ? "border-blue-700" : "border-blue-300"} hover:border-blue-700`}
       onClick={() => onSelect(data)}
     >
+      {shouldShowNew(data.created_at, data.id) && (
+        <span className="absolute top-2 left-2 bg-green-600 text-white text-xs px-2 py-1 rounded shadow-md">
+          New
+        </span>
+      )}
+
       <div className="flex flex-col pl-2">
         <figure className="w-40 h-32">
           <img
@@ -25,7 +34,7 @@ const SkipCard = ({ data, selected, onSelect }) => {
         <div className="flex items-center justify-between">
           <h2 className="card-title badge badge-info rounded">{data.size} Yards</h2>
 
-          <div className="mt-2 text-xs text-white flex gap-2">
+          <div className="text-xs text-white flex gap-2">
             <span
               className={`badge flex items-center gap-1 px-2 py-1 rounded ${
                 data.allowed_on_road

--- a/src/components/SkipDetail.jsx
+++ b/src/components/SkipDetail.jsx
@@ -1,0 +1,110 @@
+import { getSkipImageUrl } from "../utils/getSkipImageUrl";
+// import { isNew } from "../utils/isNew";
+import { shouldShowNew } from "../utils/shouldShowNew";
+
+const SkipDetail = ({ data }) => {
+  if (!data) {
+    return (
+      <div className="border-b-2 border-blue-300 rounded p-4 text-white bg-[#1E1E1E] sticky top-5">
+        <h3 className="text-lg font-semibold text-white mb-2">Organization Details</h3>
+        <p className="text-gray-400 text-sm">
+          Please select a skip from the available options to view detailed information here. This
+          section will display the selected skip’s specifications, pricing, and availability.
+        </p>
+      </div>
+    );
+  }
+
+  const backgroundUrl = getSkipImageUrl(data.size);
+
+  return (
+    <div
+      className="relative rounded overflow-hidden border-b-2 border-blue-700 sticky top-5"
+      style={{
+        backgroundImage: `url('${backgroundUrl}')`,
+        backgroundRepeat: "no-repeat",
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+      }}
+    >
+      <div className="absolute inset-0 bg-black/70" />
+
+      {shouldShowNew(data.created_at, data.id) && (
+        <span className="absolute top-2 right-2 bg-green-600 text-white text-xs px-2 py-1 rounded shadow-md">
+          New
+        </span>
+      )}
+
+      <div className="relative p-4 text-white space-y-2 z-10">
+        <h3 className="text-2xl font-bold">{data.size} Yard Skip</h3>
+        <hr className="border-b-1 w-10 border-blue-700 " />
+        <p className="text-gray-200">Hire Period: {data.hire_period_days} days</p>
+
+        <p className="text-gray-200">
+          Transport Cost:{" "}
+          {data.transport_cost !== null ? (
+            <>£{data.transport_cost}</>
+          ) : (
+            <span className="italic"> Not specified</span>
+          )}
+        </p>
+
+        <p className="text-gray-200">
+          Per Tonne Cost:{" "}
+          {data.per_tonne_cost !== null ? (
+            <>£{data.per_tonne_cost}</>
+          ) : (
+            <span className="italic">Not specified</span>
+          )}
+        </p>
+
+        <p className="text-gray-200">Price: £{data.price_before_vat}</p>
+        <p className="text-gray-200">
+          On Road:{" "}
+          <span className={data.allowed_on_road ? "text-green-400" : "text-yellow-400"}>
+            {data.allowed_on_road ? "Allowed" : "Not Allowed"}
+          </span>
+        </p>
+        <p className="text-gray-200">
+          Heavy Waste:{" "}
+          <span className={data.allows_heavy_waste ? "text-green-400" : "text-red-400"}>
+            {data.allows_heavy_waste ? "Accepted" : "Not Accepted"}
+          </span>
+        </p>
+
+        <p className="text-gray-200">Postcode: {data.postcode}</p>
+
+        <p className="text-gray-200">
+          Area:{" "}
+          {data.area && data.area.trim() !== "" ? (
+            data.area
+          ) : (
+            <span className="italic">Not specified</span>
+          )}
+        </p>
+
+        <p className="text-gray-200">
+          Availability:{" "}
+          {data.forbidden ? (
+            <span className="text-red-400 font-semibold">Not available in this postcode</span>
+          ) : (
+            <span className="text-green-400">Available</span>
+          )}
+        </p>
+
+        <p className="text-[11px] text-gray-300 pt-4 italic">
+          Imagery and information shown throughout this website may not reflect the exact shape or
+          size specification, colours may vary, options and/or accessories may be featured at
+          additional cost.
+        </p>
+
+        <div className="flex justify-end gap-4 pt-4">
+          <button className="btn btn-primary rounded">Back</button>
+          <button className="btn btn-info rounded">Continue</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SkipDetail;

--- a/src/pages/SkipSelection.jsx
+++ b/src/pages/SkipSelection.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
 
-import SkipCard from "../components/SkipCard";
 import Stepper from "../components/Stepper";
 import Title from "../components/Title";
 import Subtitle from "../components/Subtitle";
+
+import SkipCard from "../components/SkipCard";
+import SkipDetail from "../components/SkipDetail";
 
 import stepData from "../shared/data/stepData";
 import { fetchSkips } from "../services/skipService";
@@ -40,8 +42,9 @@ const SkipSelection = () => {
             />
           ))}
         </div>
+
         <div className="lg:w-1/4">
-          <div className="border-b-2 rounded p-4 text-white bg-[#1E1E1E]">Detail</div>
+          <SkipDetail data={selected} />
         </div>
       </div>
     </div>

--- a/src/utils/getSkipImageUrl.jsx
+++ b/src/utils/getSkipImageUrl.jsx
@@ -1,0 +1,3 @@
+export const getSkipImageUrl = (size) => {
+  return `/images/${size}-yarder-skip.jpg`;
+};

--- a/src/utils/isNew.jsx
+++ b/src/utils/isNew.jsx
@@ -1,0 +1,7 @@
+export const isNew = (createdAt) => {
+  const createdDate = new Date(createdAt);
+  const now = new Date();
+  const diffInMs = now - createdDate;
+  const diffInDays = diffInMs / (1000 * 60 * 60 * 24);
+  return diffInDays <= 7;
+};

--- a/src/utils/manualNewSkips.jsx
+++ b/src/utils/manualNewSkips.jsx
@@ -1,0 +1,1 @@
+export const manualNewSkipIds = [17933, 17938];

--- a/src/utils/shouldShowNew.jsx
+++ b/src/utils/shouldShowNew.jsx
@@ -1,0 +1,11 @@
+// NOTE:
+// The API currently returns the same created_at for all skips,
+// so some skips are manually marked as "New" for UI/demo purposes.
+// The actual logic for newness is handled via `isNew()`.
+
+import { isNew } from "./isNew";
+import { manualNewSkipIds } from "./manualNewSkips";
+
+export const shouldShowNew = (createdAt, id) => {
+  return isNew(createdAt) || manualNewSkipIds.includes(id);
+};


### PR DESCRIPTION
This PR introduces the following improvements:

- When a skip is selected, its detailed information is now shown in a right-hand panel.
- Skip background images are dynamically set based on the skip size.
- Skips added within the last 7 days are marked with a "New" badge.
- Since the API returns identical `created_at` timestamps for all skips, a few skip IDs have been manually marked as "New" for demonstration purposes (`manualNewSkipIds`).
- All relevant data such as `transport_cost`, `per_tonne_cost`, `price_before_vat`, `area`, `postcode`, and `forbidden` status is now displayed clearly.
- Utility functions (`isNew`, `shouldShowNew`) have been added to the `utils` directory for clean and reusable logic.

The component structure has been optimized for readability, scalability, and clarity.
