### PR TITLE
feat(ui): add skeleton loading cards for skip selection

### DIFF
--- a/src/components/SkipCardSkeleton.jsx
+++ b/src/components/SkipCardSkeleton.jsx
@@ -1,0 +1,30 @@
+const SkipCardSkeleton = () => {
+  return (
+    <div className="card card-side bg-base-200 shadow-md border border-base-300 animate-pulse">
+      <div className="pl-4 flex flex-col justify-center">
+        <figure className="w-36 h-28 bg-base-100 rounded">{/* Görsel yerine boş alan */}</figure>
+
+        <div className="flex gap-2 mt-2">
+          <div className="badge bg-gray-700 text-gray-700 w-10 h-4 rounded"></div>
+          <div className="badge bg-gray-700 text-gray-700 w-10 h-4 rounded"></div>
+        </div>
+      </div>
+
+      <div className="card-body text-sm">
+        <div className="flex justify-between items-center mb-2">
+          <div className="bg-gray-700 h-4 w-20 rounded"></div>
+          <div className="bg-gray-700 h-4 w-10 rounded"></div>
+        </div>
+
+        <div className="bg-gray-700 h-4 w-32 mb-1 rounded"></div>
+        <div className="bg-gray-700 h-3 w-24 mb-4 rounded"></div>
+
+        <div className="card-actions justify-end">
+          <div className="btn btn-sm bg-gray-700 text-gray-700 w-32 h-8 rounded"></div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SkipCardSkeleton;

--- a/src/pages/SkipSelection.jsx
+++ b/src/pages/SkipSelection.jsx
@@ -9,17 +9,22 @@ import SkipDetail from "../components/SkipDetail";
 
 import stepData from "../shared/data/stepData";
 import { fetchSkips } from "../services/skipService";
+import SkipCardSkeleton from "../components/SkipCardSkeleton";
 
 const SkipSelection = () => {
   const [skips, setSkips] = useState([]);
   const [selected, setSelected] = useState(null);
+  const [loading, setLoading] = useState(true);
 
   const handleSelect = (data) => {
     setSelected((prev) => (prev?.id === data.id ? null : data));
   };
 
   useEffect(() => {
-    fetchSkips().then(setSkips);
+    fetchSkips()
+      .then((data) => setSkips(data))
+      .catch((err) => console.error("Veri alınamadı", err))
+      .finally(() => setLoading(false));
   }, []);
 
   return (
@@ -33,14 +38,18 @@ const SkipSelection = () => {
 
       <div className="flex flex-col lg:flex-row gap-6">
         <div className="lg:w-3/4 grid gap-4 md:grid-cols-2">
-          {skips.map((item) => (
-            <SkipCard
-              key={item.id}
-              data={item}
-              selected={selected?.id === item.id}
-              onSelect={handleSelect}
-            />
-          ))}
+          {loading ? (
+            <SkipCardSkeleton />
+          ) : (
+            skips.map((item) => (
+              <SkipCard
+                key={item.id}
+                data={item}
+                selected={selected?.id === item.id}
+                onSelect={handleSelect}
+              />
+            ))
+          )}
         </div>
 
         <div className="lg:w-1/4">


### PR DESCRIPTION
Implemented the SkipCardSkeleton component to improve the loading experience.

While skip data is being fetched from the API, skeleton cards are displayed instead of an empty screen to provide a smoother and more user-friendly interface.
